### PR TITLE
#269 Corrected an error of inconsistency in full_expectation_ and full_triangle_

### DIFF
--- a/chainladder/__init__.py
+++ b/chainladder/__init__.py
@@ -42,4 +42,4 @@ from chainladder.tails import *  # noqa (API Import)
 from chainladder.methods import *  # noqa (API Import)
 from chainladder.workflow import *  # noqa (API Import)
 
-__version__ = "0.8.12"
+__version__ = "0.8.13"

--- a/chainladder/core/tests/test_triangle.py
+++ b/chainladder/core/tests/test_triangle.py
@@ -447,3 +447,7 @@ def test_origin_as_datetime_arg(clrd):
     from pandas.api.types import is_datetime64_any_dtype
     assert is_datetime64_any_dtype(clrd.to_frame(origin_as_datetime=True)['origin'])
     assert not is_datetime64_any_dtype(clrd.to_frame(origin_as_datetime=False)['origin'])
+
+def test_halfyear_grain():
+    data=pd.DataFrame({'AccMo':[201409, 201503, 201603], 'ValMo':[202203]*3, 'value':[100]*3})
+    assert cl.Triangle(data=data, origin='AccMo', development='ValMo', columns='value').shape == (1,1,16,1)

--- a/chainladder/core/triangle.py
+++ b/chainladder/core/triangle.py
@@ -144,6 +144,7 @@ class Triangle(TriangleBase):
         origin_date = origin_date.dt.to_period(self.origin_grain).dt.to_timestamp(
             how="s"
         )
+
         development_date = development_date.dt.to_period(
             self.development_grain
         ).dt.to_timestamp(how="e")
@@ -151,6 +152,7 @@ class Triangle(TriangleBase):
         data_agg = self._aggregate_data(
             data, origin_date, development_date, index, columns
         )
+
         # Fill in missing periods with zeros
         date_axes = self._get_date_axes(
             data_agg["__origin__"],
@@ -161,12 +163,11 @@ class Triangle(TriangleBase):
         # Deal with labels
         if not index:
             index = ["Total"]
-            data_agg[index[0]] = "Total"
+            data_agg[index[0]] = "Total"    
         self.kdims, key_idx = self._set_kdims(data_agg, index)
         self.vdims = np.array(columns)
         self.odims, orig_idx = self._set_odims(data_agg, date_axes)
         self.ddims, dev_idx = self._set_ddims(data_agg, date_axes)
-
         # Set remaining triangle properties
         val_date = data_agg["__development__"].max()
         val_date = val_date.compute() if hasattr(val_date, "compute") else val_date
@@ -199,7 +200,8 @@ class Triangle(TriangleBase):
         # Coerce malformed triangles to something more predictible
         check_origin = (
             pd.period_range(
-                start=self.odims.min(), end=self.valuation_date, freq=self.origin_grain
+                start=self.odims.min(), end=self.valuation_date, 
+                freq=self.origin_grain.replace('S', '2Q')
             )
             .to_timestamp()
             .values

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pandas>=0.23
 scikit-learn>=0.23
 numba
 sparse>=0.9
-matplotlib
+matplotlib-base
 dill
 patsy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pandas>=0.23
 scikit-learn>=0.23
 numba
 sparse>=0.9
-matplotlib-base
+matplotlib
 dill
 patsy

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("README.rst") as f:
 descr = "Chainladder Package - P&C Loss Reserving package "
 name = 'chainladder'
 url = 'https://github.com/casact/chainladder-python'
-version='0.8.12' # Put this in __init__.py
+version='0.8.13' # Put this in __init__.py
 
 data_path = ''
 setup(


### PR DESCRIPTION
Addressed an error and refactored the code per #269 

Test code:
``` python
def test_full_triangle_and_full_expectation(raa):
    raa_cum = raa
    assert raa_cum.is_cumulative == True

    raa_incr = raa_cum.cum_to_incr()
    assert raa_incr.is_cumulative == False
    assert raa_incr.incr_to_cum().is_cumulative == True
    assert raa_incr.incr_to_cum() == raa_cum

    cl_fit_incr = cl.Chainladder().fit(X=raa_incr)
    assert cl_fit_incr.X_.is_cumulative == False

    cl_fit_cum = cl.Chainladder().fit(X=raa_cum)
    assert cl_fit_cum.X_.is_cumulative == True

    assert cl_fit_incr.cdf_ == cl_fit_cum.cdf_
    assert cl_fit_incr.ultimate_ == cl_fit_cum.ultimate_

    assert cl_fit_cum.full_expectation_ == cl_fit_incr.full_expectation_.incr_to_cum()
    assert (
        cl_fit_cum.full_triangle_ - cl_fit_incr.full_triangle_.incr_to_cum() < 0.00001
    )
    assert (cl_fit_cum.full_triangle_ - raa_cum) - (
        cl_fit_incr.full_triangle_.incr_to_cum() - raa_incr.incr_to_cum()
    ) < 0.00001

    bf_fit_incr = cl.BornhuetterFerguson(apriori=1).fit(
        X=raa_incr, sample_weight=raa_incr.incr_to_cum().latest_diagonal * 0
    )
    assert bf_fit_incr.X_.is_cumulative == False

    bf_fit_cum = cl.BornhuetterFerguson(apriori=1).fit(
        X=raa_cum, sample_weight=raa_cum.latest_diagonal * 0
    )
    assert bf_fit_cum.X_.is_cumulative == True

    assert bf_fit_incr.cdf_ == bf_fit_cum.cdf_
    assert bf_fit_incr.ultimate_ == bf_fit_cum.ultimate_

    assert bf_fit_cum.full_expectation_ == bf_fit_incr.full_expectation_.incr_to_cum()
    assert (
        bf_fit_cum.full_triangle_ - bf_fit_incr.full_triangle_.incr_to_cum() < 0.00001
    )
    assert (bf_fit_cum.full_triangle_ - raa_cum) - (
        bf_fit_incr.full_triangle_.incr_to_cum() - raa_incr.incr_to_cum()
    ) < 0.00001
```