### PR TITLE
Correcting the errors in the calculation of LDFs in CaseOutstanding()

### DIFF
--- a/chainladder/development/outstanding.py
+++ b/chainladder/development/outstanding.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 
 class CaseOutstanding(DevelopmentBase):
-    """ A determinisic method based on outstanding case reserves.
+    """A determinisic method based on outstanding case reserves.
 
     The CaseOutstanding method is a deterministic approach that develops
     patterns of incremental payments as a percent of previous period case
@@ -49,8 +49,10 @@ class CaseOutstanding(DevelopmentBase):
     paid_ldf_:
         The selected paid to prior case ratios of the fitted estimator
     """
-    def __init__(self, paid_to_incurred=None, paid_n_periods=-1,
-                 case_n_periods=-1, groupby=None):
+
+    def __init__(
+        self, paid_to_incurred=None, paid_n_periods=-1, case_n_periods=-1, groupby=None
+    ):
         self.paid_to_incurred = paid_to_incurred
         self.paid_n_periods = paid_n_periods
         self.case_n_periods = case_n_periods
@@ -73,19 +75,36 @@ class CaseOutstanding(DevelopmentBase):
         """
         backend = "cupy" if X.array_backend == "cupy" else "numpy"
         self.X_ = X.copy()
-        self.paid_w_ = Development(n_periods=self.paid_n_periods).fit(self.X_.sum(0).sum(1)).w_
-        self.case_w_ = Development(n_periods=self.case_n_periods).fit(self.X_.sum(0).sum(1)).w_
+        self.paid_w_ = (
+            Development(n_periods=self.paid_n_periods).fit(self.X_.sum(0).sum(1)).w_
+        )
+        self.case_w_ = (
+            Development(n_periods=self.case_n_periods).fit(self.X_.sum(0).sum(1)).w_
+        )
+
+        print("=== self.case_to_prior_case_.mean(2) ===")
+        print(self.case_to_prior_case_)
+
+        case_tri = X[self.paid_to_incurred[1]] - X[self.paid_to_incurred[0]]
+        temp = Development(n_periods=self.paid_n_periods, average="simple").fit(
+            case_tri
+        )
+
+        print("=== temp ===")
+        print(temp.ldf_)
+
         self.case_ldf_ = self.case_to_prior_case_.mean(2)
         self.paid_ldf_ = self.paid_to_prior_case_.mean(2)
+        print("=== self.case_ldf_ ===")
+        print(self.case_ldf_)
         self.ldf_ = self._set_ldf(self.X_).set_backend(backend)
         return self
 
     def _set_ldf(self, X):
         paid_tri = X[self.paid_to_incurred[0]]
         incurred_tri = X[self.paid_to_incurred[1]]
-        case = incurred_tri-paid_tri
+        case = incurred_tri - paid_tri
         original_val_date = case.valuation_date
-
         case_ldf_ = self.case_ldf_.copy()
         case_ldf_.valuation_date = pd.Timestamp(options.ULT_VAL)
         xp = case_ldf_.get_array_module()
@@ -94,79 +113,100 @@ class CaseOutstanding(DevelopmentBase):
         case_ldf_.odims = case.odims
         case_ldf_.is_pattern = False
         case_ldf_.values = xp.concatenate(
-            (xp.ones(list(case_ldf_.shape[:-1])+[1]), case_ldf_.values),
-            axis=-1)
+            (xp.ones(list(case_ldf_.shape[:-1]) + [1]), case_ldf_.values), axis=-1
+        )
 
         case_ldf_.ddims = case.ddims
         case_ldf_.valuation_date = case_ldf_.valuation.max()
         case_ldf_ = case_ldf_.dev_to_val().set_backend(self.case_ldf_.array_backend)
 
         # Will this work for sparse?
-        forward = case_ldf_[case_ldf_.valuation>original_val_date].values
+        forward = case_ldf_[case_ldf_.valuation > original_val_date].values
         forward[xp.isnan(forward)] = 1.0
         forward = xp.cumprod(forward, -1)
-        1/case_ldf_[case_ldf_.valuation<=original_val_date]
+        1 / case_ldf_[case_ldf_.valuation <= original_val_date]
 
-        backward = 1/case_ldf_[case_ldf_.valuation<=original_val_date].values
+        backward = 1 / case_ldf_[case_ldf_.valuation <= original_val_date].values
         backward[xp.isnan(backward)] = 1.0
         backward = xp.cumprod(backward[..., ::-1], -1)[..., ::-1][..., 1:]
-        nans = case_ldf_/case_ldf_
-        case_ldf_.values = xp.concatenate((backward, (case.latest_diagonal*0+1).values,  forward), -1)
-        case = (case_ldf_*nans.values*case.latest_diagonal.values).val_to_dev().iloc[..., :len(case.ddims)]
-        ld = case[case.valuation==X.valuation_date].sum('development').sum('origin')
+        nans = case_ldf_ / case_ldf_
+        case_ldf_.values = xp.concatenate(
+            (backward, (case.latest_diagonal * 0 + 1).values, forward), -1
+        )
+        case = (
+            (case_ldf_ * nans.values * case.latest_diagonal.values)
+            .val_to_dev()
+            .iloc[..., : len(case.ddims)]
+        )
+        ld = case[case.valuation == X.valuation_date].sum("development").sum("origin")
         ld = ld / ld
-        patterns = ((1-np.nan_to_num(X.nan_triangle[..., 1:]))*(self.paid_ldf_*ld).values)
-        paid = (case.iloc[..., :-1]*patterns)
+        patterns = (1 - np.nan_to_num(X.nan_triangle[..., 1:])) * (
+            self.paid_ldf_ * ld
+        ).values
+        paid = case.iloc[..., :-1] * patterns
         paid.ddims = case.ddims[1:]
         paid.valuation_date = pd.Timestamp(options.ULT_VAL)
-        #Create a full triangle of incurrds to support a multiplicative LDF
+        # Create a full triangle of incurrds to support a multiplicative LDF
         paid = (paid_tri.cum_to_incr() + paid).incr_to_cum()
-        inc = (case[case.valuation>X.valuation_date] +
-               paid[paid.valuation>X.valuation_date] +
-               incurred_tri)
+        inc = (
+            case[case.valuation > X.valuation_date]
+            + paid[paid.valuation > X.valuation_date]
+            + incurred_tri
+        )
         # Combined paid and incurred into a single object
         paid.columns = [self.paid_to_incurred[0]]
         inc.columns = [self.paid_to_incurred[1]]
-        cols = X.columns[X.columns.isin([self.paid_to_incurred[0], self.paid_to_incurred[1]])]
+        cols = X.columns[
+            X.columns.isin([self.paid_to_incurred[0], self.paid_to_incurred[1]])
+        ]
         dev = concat((paid, inc), 1)[list(cols)]
         # Convert the paid/incurred to multiplicative LDF
-        dev = (dev.iloc[..., -1]/dev).iloc[..., :-1]
+        dev = (dev.iloc[..., -1] / dev).iloc[..., :-1]
         dev.valuation_date = pd.Timestamp(options.ULT_VAL)
         dev.ddims = X.link_ratio.ddims
-        dev.is_pattern=True
-        dev.is_cumulative=True
+        dev.is_pattern = True
+        dev.is_cumulative = True
         self.case = case
-        self.paid=paid
+        self.paid = paid
         return dev.cum_to_incr()
 
     @property
     def case_to_prior_case_(self):
         paid_tri = self.X_[self.paid_to_incurred[0]]
         incurred_tri = self.X_[self.paid_to_incurred[1]]
+
         if self.groupby is not None:
             paid_tri = paid_tri.groupby(self.groupby).sum()
             incurred_tri = incurred_tri.groupby(self.groupby).sum()
-        out = ((incurred_tri - paid_tri).iloc[..., 1:] * self.case_w_ /
-               (incurred_tri - paid_tri).iloc[..., :-1].values)
+        out = (
+            (incurred_tri - paid_tri).iloc[..., 1:]
+            * self.case_w_
+            / (incurred_tri - paid_tri).iloc[..., :-1].values
+        )
         out.is_pattern = True
-        out.is_cumulative=False
+        out.is_cumulative = False
         return out
 
     @property
     def paid_to_prior_case_(self):
         paid_tri = self.X_[self.paid_to_incurred[0]]
         incurred_tri = self.X_[self.paid_to_incurred[1]]
+
         if self.groupby is not None:
             paid_tri = paid_tri.groupby(self.groupby).sum()
             incurred_tri = incurred_tri.groupby(self.groupby).sum()
+
         out = (
-            paid_tri.cum_to_incr().iloc[..., 1:] * self.paid_w_ /
-            (incurred_tri - paid_tri).iloc[..., :-1].values)
-        out.is_pattern=True
+            paid_tri.cum_to_incr().iloc[..., 1:]
+            * self.paid_w_
+            / (incurred_tri - paid_tri).iloc[..., :-1].values
+        )
+        out.is_pattern = True
+
         return out
 
     def transform(self, X):
-        """ If X and self are of different shapes, align self to X, else
+        """If X and self are of different shapes, align self to X, else
         return self.
 
         Parameters

--- a/chainladder/development/tests/test_outstanding.py
+++ b/chainladder/development/tests/test_outstanding.py
@@ -1,9 +1,60 @@
 import chainladder as cl
+import numpy as np
+
 
 def test_basic_case_outstanding():
-    tri = cl.load_sample('usauto')
-    m = cl.CaseOutstanding(paid_to_incurred=('paid', 'incurred')).fit(tri)
+    tri = cl.load_sample("usauto")
+    m = cl.CaseOutstanding(paid_to_incurred=("paid", "incurred")).fit(tri)
     out = cl.Chainladder().fit(m.fit_transform(tri))
-    a = (out.full_triangle_['incurred']-out.full_triangle_['paid']).iloc[..., -1, :9]*m.paid_ldf_.values
-    b = (out.full_triangle_['paid'].cum_to_incr().iloc[..., -1, 1:10]).values
-    assert (a-b).max() < 1e-6
+    a = (out.full_triangle_["incurred"] - out.full_triangle_["paid"]).iloc[
+        ..., -1, :9
+    ] * m.paid_ldf_.values
+    b = (out.full_triangle_["paid"].cum_to_incr().iloc[..., -1, 1:10]).values
+    assert (a - b).max() < 1e-6
+
+
+def test_outstanding_friedland_example():
+    usauto = cl.load_sample("usauto")
+    model = cl.CaseOutstanding(
+        paid_to_incurred=("paid", "incurred"), paid_n_periods=3, case_n_periods=3
+    ).fit(usauto)
+
+    expected_paid_ldf = np.array(
+        [
+            [
+                0.833,
+                0.701,
+                0.714,
+                0.714,
+                0.653,
+                0.631,
+                0.553,
+                0.437,
+                0.524,
+            ]
+        ]
+    )
+    assert (
+        model.paid_ldf_.to_frame(origin_as_datetime=False).values - expected_paid_ldf
+        < 0.001
+    ).all()
+
+    expected_case_ldf = np.array(
+        [
+            [
+                0.526,
+                0.566,
+                0.528,
+                0.486,
+                0.511,
+                0.555,
+                0.652,
+                0.674,
+                0.580,
+            ]
+        ]
+    )
+    assert (
+        model.case_ldf_.to_frame(origin_as_datetime=False).values - expected_case_ldf
+        < 0.001
+    ).all()


### PR DESCRIPTION
Per #283, the error was the resulting of averaging the zero LDFs in.

Test code: 
```python
import chainladder as cl
import numpy as np
usauto = cl.load_sample("usauto")
model = cl.CaseOutstanding(
    paid_to_incurred=("paid", "incurred"), paid_n_periods=3, case_n_periods=3
).fit(usauto)
expected_paid_ldf = np.array(
    [[0.833, 0.701, 0.714, 0.714, 0.653, 0.631, 0.553, 0.437, 0.524,]]
)
assert (
    model.paid_ldf_.to_frame(origin_as_datetime=False).values - expected_paid_ldf
    < 0.001
).all()

expected_case_ldf = np.array(
    [[0.526, 0.566, 0.528, 0.486, 0.511, 0.555, 0.652, 0.674, 0.580,]]
)
assert (
    model.case_ldf_.to_frame(origin_as_datetime=False).values - expected_case_ldf
    < 0.001
).all()
```